### PR TITLE
add custom probe configurations

### DIFF
--- a/builder/resources/apps/common_pods.go
+++ b/builder/resources/apps/common_pods.go
@@ -225,16 +225,19 @@ func (builder *PodBuilder) AddImagePullSecrets(secretNames ...string) {
 	builder.Spec.ImagePullSecrets = utils.MergeLocalObjectReference(builder.Spec.ImagePullSecrets, secretReference)
 }
 
+// SetStartupProbeConfiguration set the startup probe configuration for the container
 func (builder *PodBuilder) SetStartupProbeConfiguration(containerName string, config types.ProbeConfiguration) {
 	container := builder.GetContainer(containerName)
 	ApplyProbeConfiguration(container.StartupProbe, config)
 }
 
+// SetLivenessProbeConfiguration set the liveness probe configuration for the container
 func (builder *PodBuilder) SetLivenessProbeConfiguration(containerName string, config types.ProbeConfiguration) {
 	container := builder.GetContainer(containerName)
 	ApplyProbeConfiguration(container.LivenessProbe, config)
 }
 
+// SetReadinessProbeConfiguration set the readiness probe configuration for the container
 func (builder *PodBuilder) SetReadinessProbeConfiguration(containerName string, config types.ProbeConfiguration) {
 	container := builder.GetContainer(containerName)
 	ApplyProbeConfiguration(container.ReadinessProbe, config)

--- a/builder/resources/apps/common_pods.go
+++ b/builder/resources/apps/common_pods.go
@@ -249,6 +249,21 @@ func (builder *PodBuilder) SetReadinessProbe(containerName string, probe v1.Prob
 	}
 }
 
+func (builder *PodBuilder) SetStartupProbeConfiguration(containerName string, config types.ProbeConfiguration) {
+	container := builder.GetContainer(containerName)
+	setProbeConfiguration(container.StartupProbe, config)
+}
+
+func (builder *PodBuilder) SetLivenessProbeConfiguration(containerName string, config types.ProbeConfiguration) {
+	container := builder.GetContainer(containerName)
+	setProbeConfiguration(container.LivenessProbe, config)
+}
+
+func (builder *PodBuilder) SetReadinessProbeConfiguration(containerName string, config types.ProbeConfiguration) {
+	container := builder.GetContainer(containerName)
+	setProbeConfiguration(container.ReadinessProbe, config)
+}
+
 // SetServiceAccountName set the service account of the pod
 func (builder *PodBuilder) SetServiceAccountName(serviceAccountName string) {
 	builder.Spec.ServiceAccountName = serviceAccountName

--- a/builder/resources/apps/common_pods.go
+++ b/builder/resources/apps/common_pods.go
@@ -251,17 +251,17 @@ func (builder *PodBuilder) SetReadinessProbe(containerName string, probe v1.Prob
 
 func (builder *PodBuilder) SetStartupProbeConfiguration(containerName string, config types.ProbeConfiguration) {
 	container := builder.GetContainer(containerName)
-	setProbeConfiguration(container.StartupProbe, config)
+	ApplyProbeConfiguration(container.StartupProbe, config)
 }
 
 func (builder *PodBuilder) SetLivenessProbeConfiguration(containerName string, config types.ProbeConfiguration) {
 	container := builder.GetContainer(containerName)
-	setProbeConfiguration(container.LivenessProbe, config)
+	ApplyProbeConfiguration(container.LivenessProbe, config)
 }
 
 func (builder *PodBuilder) SetReadinessProbeConfiguration(containerName string, config types.ProbeConfiguration) {
 	container := builder.GetContainer(containerName)
-	setProbeConfiguration(container.ReadinessProbe, config)
+	ApplyProbeConfiguration(container.ReadinessProbe, config)
 }
 
 // SetServiceAccountName set the service account of the pod

--- a/builder/resources/apps/common_pods.go
+++ b/builder/resources/apps/common_pods.go
@@ -225,30 +225,6 @@ func (builder *PodBuilder) AddImagePullSecrets(secretNames ...string) {
 	builder.Spec.ImagePullSecrets = utils.MergeLocalObjectReference(builder.Spec.ImagePullSecrets, secretReference)
 }
 
-// SetStartupProbe set the startup probe of the container
-func (builder *PodBuilder) SetStartupProbe(containerName string, probe v1.Probe) {
-	container := builder.GetContainer(containerName)
-	if container != nil {
-		container.StartupProbe = &probe
-	}
-}
-
-// SetLivenessProbe set the liveness probe of the container
-func (builder *PodBuilder) SetLivenessProbe(containerName string, probe v1.Probe) {
-	container := builder.GetContainer(containerName)
-	if container != nil {
-		container.LivenessProbe = &probe
-	}
-}
-
-// SetReadinessProbe set the readiness probe of the container
-func (builder *PodBuilder) SetReadinessProbe(containerName string, probe v1.Probe) {
-	container := builder.GetContainer(containerName)
-	if container != nil {
-		container.ReadinessProbe = &probe
-	}
-}
-
 func (builder *PodBuilder) SetStartupProbeConfiguration(containerName string, config types.ProbeConfiguration) {
 	container := builder.GetContainer(containerName)
 	ApplyProbeConfiguration(container.StartupProbe, config)

--- a/builder/resources/apps/container.go
+++ b/builder/resources/apps/container.go
@@ -54,24 +54,6 @@ func (c *ContainerBuilder) SetImage(image string) *ContainerBuilder {
 	return c
 }
 
-// SetReadinessProbe Set the readiness probe for the container
-func (c *ContainerBuilder) SetReadinessProbe(readinessProbe v1.Probe) *ContainerBuilder {
-	c.ReadinessProbe = readinessProbe.DeepCopy()
-	return c
-}
-
-// SetLivenessProbe Set the liveness probe for the container
-func (c *ContainerBuilder) SetLivenessProbe(livenessProbe v1.Probe) *ContainerBuilder {
-	c.LivenessProbe = livenessProbe.DeepCopy()
-	return c
-}
-
-// SetStartupProbe Set the startup probe for the container
-func (c *ContainerBuilder) SetStartupProbe(startupProbe v1.Probe) *ContainerBuilder {
-	c.StartupProbe = startupProbe.DeepCopy()
-	return c
-}
-
 // SetReadinessProbeConfiguration Set the readiness probe's configuration for the container
 func (c *ContainerBuilder) SetReadinessProbeConfiguration(config types.ProbeConfiguration) *ContainerBuilder {
 	ApplyProbeConfiguration(c.ReadinessProbe, config)

--- a/builder/resources/apps/container.go
+++ b/builder/resources/apps/container.go
@@ -1,6 +1,7 @@
 package apps
 
 import (
+	"github.com/davidboxer/formation/types"
 	"strconv"
 	"strings"
 
@@ -68,6 +69,24 @@ func (c *ContainerBuilder) SetLivenessProbe(livenessProbe v1.Probe) *ContainerBu
 // SetStartupProbe Set the startup probe for the container
 func (c *ContainerBuilder) SetStartupProbe(startupProbe v1.Probe) *ContainerBuilder {
 	c.StartupProbe = startupProbe.DeepCopy()
+	return c
+}
+
+// SetReadinessProbeConfiguration Set the readiness probe's configuration for the container
+func (c *ContainerBuilder) SetReadinessProbeConfiguration(config types.ProbeConfiguration) *ContainerBuilder {
+	setProbeConfiguration(c.ReadinessProbe, config)
+	return c
+}
+
+// SetLivenessProbeConfiguration Set the liveness probe's configuration for the container
+func (c *ContainerBuilder) SetLivenessProbeConfiguration(config types.ProbeConfiguration) *ContainerBuilder {
+	setProbeConfiguration(c.LivenessProbe, config)
+	return c
+}
+
+// SetStartupProbeConfiguration Set the startup probe's configuration for the container
+func (c *ContainerBuilder) SetStartupProbeConfiguration(config types.ProbeConfiguration) *ContainerBuilder {
+	setProbeConfiguration(c.StartupProbe, config)
 	return c
 }
 

--- a/builder/resources/apps/container.go
+++ b/builder/resources/apps/container.go
@@ -74,19 +74,19 @@ func (c *ContainerBuilder) SetStartupProbe(startupProbe v1.Probe) *ContainerBuil
 
 // SetReadinessProbeConfiguration Set the readiness probe's configuration for the container
 func (c *ContainerBuilder) SetReadinessProbeConfiguration(config types.ProbeConfiguration) *ContainerBuilder {
-	setProbeConfiguration(c.ReadinessProbe, config)
+	ApplyProbeConfiguration(c.ReadinessProbe, config)
 	return c
 }
 
 // SetLivenessProbeConfiguration Set the liveness probe's configuration for the container
 func (c *ContainerBuilder) SetLivenessProbeConfiguration(config types.ProbeConfiguration) *ContainerBuilder {
-	setProbeConfiguration(c.LivenessProbe, config)
+	ApplyProbeConfiguration(c.LivenessProbe, config)
 	return c
 }
 
 // SetStartupProbeConfiguration Set the startup probe's configuration for the container
 func (c *ContainerBuilder) SetStartupProbeConfiguration(config types.ProbeConfiguration) *ContainerBuilder {
-	setProbeConfiguration(c.StartupProbe, config)
+	ApplyProbeConfiguration(c.StartupProbe, config)
 	return c
 }
 

--- a/builder/resources/apps/utils.go
+++ b/builder/resources/apps/utils.go
@@ -12,12 +12,12 @@ func ApplyProbeConfiguration(probe *v1.Probe, config types.ProbeConfiguration) {
 	if probe == nil {
 		return
 	}
-	// If the  probe is not enabled, set the probe to nil
+	// If the probe is not enabled in the configuration, set the probe to nil
 	if !config.Enable {
 		probe = nil
 		return
 	}
-	// Set the probe's parameters
+	// If the probe is enabled in the configuration, set the probe's parameters
 	if config.InitialDelaySeconds != nil {
 		probe.InitialDelaySeconds = *config.InitialDelaySeconds
 	}

--- a/builder/resources/apps/utils.go
+++ b/builder/resources/apps/utils.go
@@ -1,0 +1,36 @@
+package apps
+
+import (
+	"github.com/davidboxer/formation/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// setProbeConfiguration set the probe's parameters based on the configuration.
+// If the probe is nil then the configuration is not applied.
+func setProbeConfiguration(probe *v1.Probe, config types.ProbeConfiguration) {
+	// If the probe is nil, don't configure
+	if probe == nil {
+		return
+	}
+	// If the  probe is not enabled, set the probe to nil
+	if !config.Enable {
+		probe = nil
+		return
+	}
+	// Set the probe's parameters
+	if config.InitialDelaySeconds != nil {
+		probe.InitialDelaySeconds = *config.InitialDelaySeconds
+	}
+	if config.TimeoutSeconds != nil {
+		probe.TimeoutSeconds = *config.TimeoutSeconds
+	}
+	if config.PeriodSeconds != nil {
+		probe.PeriodSeconds = *config.PeriodSeconds
+	}
+	if config.SuccessThreshold != nil {
+		probe.SuccessThreshold = *config.SuccessThreshold
+	}
+	if config.FailureThreshold != nil {
+		probe.FailureThreshold = *config.FailureThreshold
+	}
+}

--- a/builder/resources/apps/utils.go
+++ b/builder/resources/apps/utils.go
@@ -5,9 +5,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// setProbeConfiguration set the probe's parameters based on the configuration.
+// ApplyProbeConfiguration set the probe's parameters based on the configuration.
 // If the probe is nil then the configuration is not applied.
-func setProbeConfiguration(probe *v1.Probe, config types.ProbeConfiguration) {
+func ApplyProbeConfiguration(probe *v1.Probe, config types.ProbeConfiguration) {
 	// If the probe is nil, don't configure
 	if probe == nil {
 		return

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -74,13 +74,13 @@ type ConfigurableContainer interface {
 	SetLivenessProbe(containerName string, probe v1.Probe)
 
 	// SetStartupProbeConfiguration Set the startup probe configuration for the container
-	SetStartupProbeConfiguration(containerName string, probe v1.Probe)
+	SetStartupProbeConfiguration(containerName string, probe ProbeConfiguration)
 
 	// SetReadinessProbeConfiguration Set the readiness probe configuration for the container
-	SetReadinessProbeConfiguration(containerName string, probe v1.Probe)
+	SetReadinessProbeConfiguration(containerName string, probe ProbeConfiguration)
 
 	// SetLivenessProbeConfiguration Set the liveness probe configuration for the container
-	SetLivenessProbeConfiguration(containerName string, probe v1.Probe)
+	SetLivenessProbeConfiguration(containerName string, probe ProbeConfiguration)
 }
 
 // ConfigurablePod is the interface that allows the user to customize the Pod

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -64,15 +64,6 @@ type ConfigurableContainer interface {
 
 	SetImagePullPolicy(containerName string, policy v1.PullPolicy)
 
-	// SetStartupProbe Set the startup probe for the container
-	SetStartupProbe(containerName string, probe v1.Probe)
-
-	// SetReadinessProbe Set the readiness probe for the container
-	SetReadinessProbe(containerName string, probe v1.Probe)
-
-	// SetLivenessProbe Set the liveness probe for the container
-	SetLivenessProbe(containerName string, probe v1.Probe)
-
 	// SetStartupProbeConfiguration Set the startup probe configuration for the container
 	SetStartupProbeConfiguration(containerName string, probe ProbeConfiguration)
 

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -72,6 +72,15 @@ type ConfigurableContainer interface {
 
 	// SetLivenessProbe Set the liveness probe for the container
 	SetLivenessProbe(containerName string, probe v1.Probe)
+
+	// SetStartupProbeConfiguration Set the startup probe configuration for the container
+	SetStartupProbeConfiguration(containerName string, probe v1.Probe)
+
+	// SetReadinessProbeConfiguration Set the readiness probe configuration for the container
+	SetReadinessProbeConfiguration(containerName string, probe v1.Probe)
+
+	// SetLivenessProbeConfiguration Set the liveness probe configuration for the container
+	SetLivenessProbeConfiguration(containerName string, probe v1.Probe)
 }
 
 // ConfigurablePod is the interface that allows the user to customize the Pod

--- a/types/type.go
+++ b/types/type.go
@@ -72,6 +72,64 @@ type LinkVolumeData struct {
 	EnvFromSource *v1.EnvFromSource `json:"envFromSource,omitempty" yaml:"envFromSource"`
 }
 
+type ProbeConfiguration struct {
+	// Enable specifies whether the probe is enabled.
+	// The default value is true.
+	// +kubebuilder:default=true
+	// +optional
+	Enable bool `json:"enable" yaml:"enable"`
+	// Number of seconds after the container has started before liveness probes are initiated.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	InitialDelaySeconds *int32 `json:"initialDelaySeconds,omitempty" protobuf:"varint,2,opt,name=initialDelaySeconds"`
+	// Number of seconds after which the probe times out.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty" protobuf:"varint,3,opt,name=timeoutSeconds"`
+	// How often (in seconds) to perform the probe.
+	// +optional
+	PeriodSeconds *int32 `json:"periodSeconds,omitempty" protobuf:"varint,4,opt,name=periodSeconds"`
+	// Minimum consecutive successes for the probe to be considered successful after having failed.
+	// +optional
+	SuccessThreshold *int32 `json:"successThreshold,omitempty" protobuf:"varint,5,opt,name=successThreshold"`
+	// Minimum consecutive failures for the probe to be considered failed after having succeeded.
+	// +optional
+	FailureThreshold *int32 `json:"failureThreshold,omitempty" protobuf:"varint,6,opt,name=failureThreshold"`
+}
+
+func (in *ProbeConfiguration) DeepCopyInto(t *ProbeConfiguration) {
+	t.Enable = in.Enable
+	if in.InitialDelaySeconds != nil {
+		t.InitialDelaySeconds = new(int32)
+		*t.InitialDelaySeconds = *in.InitialDelaySeconds
+	}
+	if in.TimeoutSeconds != nil {
+		t.TimeoutSeconds = new(int32)
+		*t.TimeoutSeconds = *in.TimeoutSeconds
+	}
+	if in.PeriodSeconds != nil {
+		t.PeriodSeconds = new(int32)
+		*t.PeriodSeconds = *in.PeriodSeconds
+	}
+	if in.SuccessThreshold != nil {
+		t.SuccessThreshold = new(int32)
+		*t.SuccessThreshold = *in.SuccessThreshold
+	}
+	if in.FailureThreshold != nil {
+		t.FailureThreshold = new(int32)
+		*t.FailureThreshold = *in.FailureThreshold
+	}
+}
+
+func (in *ProbeConfiguration) DeepCopy() *ProbeConfiguration {
+	if in == nil {
+		return nil
+	}
+	out := new(ProbeConfiguration)
+	in.DeepCopyInto(out)
+	return out
+}
+
 type FormationStatusInterface interface {
 	GetStatus() *FormationStatus
 }


### PR DESCRIPTION
Add custom probe configurations. The custom probe configurations allow the probe's parameters to be configured but not the probe's action